### PR TITLE
🌟(#34) 가족카드 기능 추가 및 수정

### DIFF
--- a/src/main/java/com/shinhan/knockknock/controller/CardController.java
+++ b/src/main/java/com/shinhan/knockknock/controller/CardController.java
@@ -6,13 +6,16 @@ import com.shinhan.knockknock.domain.dto.ReadCardResponse;
 import com.shinhan.knockknock.service.CardIssueService;
 import com.shinhan.knockknock.service.CardService;
 import com.shinhan.knockknock.service.ClovaOCRService;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @CrossOrigin
 @RestController
-@RequestMapping("/card")
-public class CardIssueRestController {
+@RequestMapping("/api/v1/card")
+public class CardController {
 
     @Autowired
     CardIssueService cardIssueService;
@@ -21,21 +24,20 @@ public class CardIssueRestController {
     @Autowired
     ClovaOCRService clovaOCRService;
 
-    // 카드 발급
+    @Operation(summary = "카드 발급", description= "")
     @PostMapping("/apply")
-    public CreateCardIssueResponse createCardIssue(@RequestBody CreateCardIssueRequest request) {
+    public CreateCardIssueResponse createPersonalCardIssue(@RequestBody CreateCardIssueRequest request) {
         CreateCardIssueResponse createCardIssueResponse = cardIssueService.createPostCardIssue(request);
         return createCardIssueResponse;
     }
 
-    // 카드 조회
+    @Operation(summary = "본인 카드 조회", description ="발급 신청 후 비동기로 발급되어 1분 후 조회 가능")
     @GetMapping("/read/{userNo}")
-    public ReadCardResponse readDetail(@PathVariable("userNo") Long userNo) {
-        ReadCardResponse readCardResponse = cardService.readGetCard(userNo);
-        return readCardResponse;
+    public List<ReadCardResponse> readDetail(@PathVariable("userNo") Long userNo) {
+        return (List<ReadCardResponse>)cardService.readGetCards(userNo);
     }
 
-    // 신분증 인증 보류
+    @Operation(summary = "신분증 인증 보류")
     @PostMapping("/auth")
     public void ocrService() {
         clovaOCRService.ocrService();

--- a/src/main/java/com/shinhan/knockknock/domain/dto/CreateCardIssueRequest.java
+++ b/src/main/java/com/shinhan/knockknock/domain/dto/CreateCardIssueRequest.java
@@ -28,4 +28,7 @@ public class CreateCardIssueRequest {
     private String cardIssuePurpose;
     private Timestamp cardIssueIssueDate;
     private Long userNo;
+    private String cardIssueAddress;
+    private boolean cardIssueIsFamily;
+    private String cardIssuePassword;
 }

--- a/src/main/java/com/shinhan/knockknock/domain/dto/ReadCardResponse.java
+++ b/src/main/java/com/shinhan/knockknock/domain/dto/ReadCardResponse.java
@@ -21,4 +21,6 @@ public class ReadCardResponse {
     private String cardExpiredate;
     //private Long issueNo;
     //private Long userNo;
+    private String cardAddress;
+    private boolean cardIsFamily;
 }

--- a/src/main/java/com/shinhan/knockknock/domain/entity/CardEntity.java
+++ b/src/main/java/com/shinhan/knockknock/domain/entity/CardEntity.java
@@ -36,7 +36,7 @@ public class CardEntity {
 
     @Column(name= "card_password")
     @NotNull
-    private int cardPassword;
+    private String cardPassword;
 
     @Column(name= "card_bank")
     @NotNull
@@ -61,4 +61,12 @@ public class CardEntity {
     @Column(name= "user_no")
     @NotNull
     private Long userNo;
+
+    @Column(name= "card_isfamily")
+    @NotNull
+    private boolean cardIsfamily;
+
+    @Column(name= "card_address")
+    @NotNull
+    private String cardAddress;
 }

--- a/src/main/java/com/shinhan/knockknock/domain/entity/CardIssueEntity.java
+++ b/src/main/java/com/shinhan/knockknock/domain/entity/CardIssueEntity.java
@@ -79,5 +79,13 @@ public class CardIssueEntity {
     @NotNull
     private Long userNo;
 
+    @Column(name= "cardissue_isfamily")
+    @NotNull
+    private boolean cardIssueIsFamily;
+
+    @Column(name= "cardissue_address")
+    @NotNull
+    private String cardIssueAddress;
+
 }
 

--- a/src/main/java/com/shinhan/knockknock/repository/CardRepository.java
+++ b/src/main/java/com/shinhan/knockknock/repository/CardRepository.java
@@ -3,5 +3,8 @@ package com.shinhan.knockknock.repository;
 import com.shinhan.knockknock.domain.entity.CardEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CardRepository extends JpaRepository<CardEntity, Long> {
+    List<CardEntity> findByUserNo(Long userNo);
 }

--- a/src/main/java/com/shinhan/knockknock/service/CardIssueService.java
+++ b/src/main/java/com/shinhan/knockknock/service/CardIssueService.java
@@ -25,6 +25,8 @@ public interface CardIssueService {
                 .cardIssueIsHighrisk(request.isCardIssueIsHighrisk())
                 .cardIssuePurpose(request.getCardIssuePurpose())
                 .userNo(request.getUserNo())
+                .cardIssueIsFamily(request.isCardIssueIsFamily())
+                .cardIssueAddress(request.getCardIssueAddress())
                 .build();
 
         return cardIssueEntity;

--- a/src/main/java/com/shinhan/knockknock/service/CardIssueServiceImpl.java
+++ b/src/main/java/com/shinhan/knockknock/service/CardIssueServiceImpl.java
@@ -18,11 +18,14 @@ public class CardIssueServiceImpl implements CardIssueService {
 
     @Override
     public CreateCardIssueResponse createPostCardIssue(CreateCardIssueRequest request) {
+
+        String password = request.getCardIssuePassword();
+
         // CardIssueEntity 생성
         CardIssueEntity cardIssueEntity = cardIssueRepository.save(transformDTOToEntity(request));
 
-        // 5분 후에 카드 발급 수행
-        cardService.scheduleCreateCard(cardIssueEntity);
+        // 1분 후에 카드 발급 수행
+        cardService.scheduleCreatePostCard(cardIssueEntity, password);
 
         return CreateCardIssueResponse.builder()
                 .message("카드 발급 요청이 접수되었습니다.")

--- a/src/main/java/com/shinhan/knockknock/service/CardService.java
+++ b/src/main/java/com/shinhan/knockknock/service/CardService.java
@@ -5,16 +5,18 @@ import com.shinhan.knockknock.domain.dto.ReadCardResponse;
 import com.shinhan.knockknock.domain.entity.CardEntity;
 import com.shinhan.knockknock.domain.entity.CardIssueEntity;
 
+import java.util.List;
+
 public interface CardService {
 
     // 비동기 카드 발급 수헹
-    public void scheduleCreateCard(CardIssueEntity cardIssueEntity);
+    public void scheduleCreatePostCard(CardIssueEntity cardIssueEntity, String password);
 
     // 카드 발급
-    public CreateCardIssueResponse createCard(CardIssueEntity cardIssueEntity);
+    public CreateCardIssueResponse createPostCard(CardIssueEntity cardIssueEntity, String password);
 
-    // 카드 조회
-    public ReadCardResponse readGetCard(Long userNo);
+    // 본인 카드 조회
+    public List<ReadCardResponse> readGetCards(Long userNo);
 
     // Entity -> DTO
     default ReadCardResponse transformEntityToDTO(CardEntity cardEntity){
@@ -27,7 +29,10 @@ public interface CardService {
                 .cardAccount(cardEntity.getCardAccount())
                 .cardAmountDate(cardEntity.getCardAmountDate())
                 .cardExpiredate(cardEntity.getCardExpiredate().toString())
+                .cardAddress(cardEntity.getCardAddress())
+                .cardIsFamily(cardEntity.isCardIsfamily())
                 .build();
         return readCardResponse;
     }
+
 }


### PR DESCRIPTION
## 🌟(#34) 가족카드 기능 추가 및 수정


## ✍️내용
- 개인카드 발급 이후, 가족카드 함께 발급시 개인카드의 공통정보로 가족카드 추가 발급 (발급 과정과 맵핑 동일)
- 카드 조회시 회원 No 기준으로 카드 모두 조회되도록 수정(e.g. 본인 기준의 개인카드와 가족카드 모두 조회 가능)
- JPARepository의 기본제공 메서드 findById 메서드 사용했어서 UserNo 값을 cardId(기본키) 컬럼에 조회하고 있었음.
- 스웨거 태그, 컨트롤러명 등 수정

## 📸스크린샷
<img width="896" alt="image" src="https://github.com/user-attachments/assets/d4363852-a048-4ad5-b275-43f6fa68afee">

- 본인 명의 카드 모두 조회되도록 Repository 수정

## 🎈참고사항

## ✅PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [x] main 브랜치에 PR 요청 인지 develop 브랜치에 PR 요청 인지 확인했습니다.