### PR TITLE
🌟(#53 ) 카드 조회 기능 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'
 	implementation("com.googlecode.json-simple:json-simple:1.1.1")
+	testImplementation 'com.h2database:h2'
 
 }
 
@@ -43,4 +44,10 @@ tasks.named('test') {
 
 springBoot {
 	mainClass = 'com.shinhan.knockknock.BackendApplication'
+}
+
+test {
+	environment 'DB_URL', 'jdbc:postgresql://122.128.54.136:54322/knock-knock'
+	environment 'DB_USERNAME', 'postgres'
+	environment 'DB_PASSWORD', '1q2w3e'
 }

--- a/src/main/java/com/shinhan/knockknock/controller/CardController.java
+++ b/src/main/java/com/shinhan/knockknock/controller/CardController.java
@@ -8,6 +8,7 @@ import com.shinhan.knockknock.service.CardService;
 import com.shinhan.knockknock.service.ClovaOCRService;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -24,9 +25,15 @@ public class CardController {
     @Autowired
     ClovaOCRService clovaOCRService;
 
-    @Operation(summary = "카드 발급", description= "")
+    /*
+    200 OK: 서버가 요청을 성공적으로 처리했으며, 그 결과를 클라이언트에게 반환하고 있다는 것을 의미
+    202 ACCEPTED: 서버가 요청을 수신했으며, 이를 처리할 것임을 의미(비동기)
+    따라서 비동기 작업 수행시 202로 변경 (test 위해서)
+     */
+    @Operation(summary = "카드 발급", description= "발급 신청 폼 받고 1분 후 카드 발급")
     @PostMapping("/apply")
-    public CreateCardIssueResponse createPersonalCardIssue(@RequestBody CreateCardIssueRequest request) {
+    @ResponseStatus(HttpStatus.ACCEPTED) // 비동기 테스트 위해서 ACCEPTED로 가도록 추가
+    public CreateCardIssueResponse createCardIssue(@RequestBody CreateCardIssueRequest request) {
         CreateCardIssueResponse createCardIssueResponse = cardIssueService.createPostCardIssue(request);
         return createCardIssueResponse;
     }

--- a/src/main/java/com/shinhan/knockknock/domain/dto/ReadCardResponse.java
+++ b/src/main/java/com/shinhan/knockknock/domain/dto/ReadCardResponse.java
@@ -3,12 +3,14 @@ package com.shinhan.knockknock.domain.dto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.sql.Date;
 
 @Data
 @Builder
 @AllArgsConstructor
+@NoArgsConstructor
 public class ReadCardResponse {
     //private Long cardId;
     private String cardNo;
@@ -23,4 +25,5 @@ public class ReadCardResponse {
     //private Long userNo;
     private String cardAddress;
     private boolean cardIsFamily;
+    private String cardResponseMessage;
 }

--- a/src/main/java/com/shinhan/knockknock/repository/CardIssueRepository.java
+++ b/src/main/java/com/shinhan/knockknock/repository/CardIssueRepository.java
@@ -2,7 +2,10 @@ package com.shinhan.knockknock.repository;
 
 import com.shinhan.knockknock.domain.entity.CardIssueEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CardIssueRepository extends JpaRepository<CardIssueEntity, Long> {
-
+    @Query("SELECT COUNT(c) FROM CardIssueEntity c WHERE c.userNo = :userNo")
+    int countByUserNo(@Param("userNo") Long userNo);
 }

--- a/src/main/java/com/shinhan/knockknock/service/CardServiceImpl.java
+++ b/src/main/java/com/shinhan/knockknock/service/CardServiceImpl.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Service;
 import java.sql.Date;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;

--- a/src/main/java/com/shinhan/knockknock/service/CardServiceImpl.java
+++ b/src/main/java/com/shinhan/knockknock/service/CardServiceImpl.java
@@ -4,6 +4,7 @@ import com.shinhan.knockknock.domain.dto.CreateCardIssueResponse;
 import com.shinhan.knockknock.domain.dto.ReadCardResponse;
 import com.shinhan.knockknock.domain.entity.CardEntity;
 import com.shinhan.knockknock.domain.entity.CardIssueEntity;
+import com.shinhan.knockknock.repository.CardIssueRepository;
 import com.shinhan.knockknock.repository.CardRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Service;
 
 import java.sql.Date;
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.Executors;
@@ -24,6 +26,8 @@ public class CardServiceImpl implements CardService {
 
     @Autowired
     CardRepository cardRepository;
+    @Autowired
+    CardIssueRepository cardIssueRepository;
 
     private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
 
@@ -85,23 +89,39 @@ public class CardServiceImpl implements CardService {
     // 본인 카드 조회
     @Override
     public List<ReadCardResponse> readGetCards(Long userNo) {
+        int countCardIssue = 0;
         // 여러 ID에 해당하는 CardEntity 목록 조회
         List<CardEntity> cardEntities = cardRepository.findByUserNo(userNo);
 
-        // 각 CardEntity를 ReadCardResponse로 변환
-        List<ReadCardResponse> readCardResponses = cardEntities.stream()
-                .map(this::transformEntityToDTO)
-                .collect(Collectors.toList());
+        if(cardEntities.isEmpty()){ // 1. if 발급된 카드가 없다
+            countCardIssue = cardIssueRepository.countByUserNo(userNo);
+            // System.out.println("카드이슈건수: " + countCardIssue);
+            if (countCardIssue == 0){ // 2. if CardIssue 테이블에 신청 정보가 없다 -> 발급된 카드가 없습니다.
+                ReadCardResponse readCardResponse = new ReadCardResponse();
+                readCardResponse.setCardResponseMessage("발급된 카드가 없습니다.");
+                return Collections.singletonList(readCardResponse); // 단건 메시지 응답
+            } else { // 3. CardIssue 테이블에 신청 정보가 있다 -> 발급 대기중입니다.
+                ReadCardResponse response = new ReadCardResponse();
+                response.setCardResponseMessage("카드 발급이 대기 중입니다.");
+                return Collections.singletonList(response); // 단건 메시지 응답
+            }
 
-        // 만료 일자 형식 변환
-        readCardResponses.forEach(readCardResponse -> {
-            String cardExpireDate = readCardResponse.getCardExpiredate();
-            String date = cardExpireDate.substring(2,7);
-            date = date.replace("-", "/");
-            readCardResponse.setCardExpiredate(date);
-        });
+        } else {
+            // 각 CardEntity를 ReadCardResponse로 변환
+            List<ReadCardResponse> readCardResponses = cardEntities.stream()
+                    .map(this::transformEntityToDTO)
+                    .collect(Collectors.toList());
 
-        return readCardResponses;
+            // 만료 일자 형식 변환
+            readCardResponses.forEach(readCardResponse -> {
+                String cardExpireDate = readCardResponse.getCardExpiredate();
+                String date = cardExpireDate.substring(2, 7);
+                date = date.replace("-", "/");
+                readCardResponse.setCardExpiredate(date);
+            });
+
+            return readCardResponses;
+        }
     }
 
 

--- a/src/test/java/com/shinhan/knockknock/controller/CardControllerTest.java
+++ b/src/test/java/com/shinhan/knockknock/controller/CardControllerTest.java
@@ -1,0 +1,138 @@
+package com.shinhan.knockknock.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.shinhan.knockknock.domain.dto.CreateCardIssueRequest;
+import com.shinhan.knockknock.domain.dto.CreateCardIssueResponse;
+import com.shinhan.knockknock.domain.dto.ReadCardResponse;
+import com.shinhan.knockknock.service.CardIssueService;
+import com.shinhan.knockknock.service.CardService;
+import com.shinhan.knockknock.service.ClovaOCRService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.sql.Date;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CardController.class)
+public class CardControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    // 직렬화에 사용 ( 객체를 json으로 )
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private CardIssueService cardIssueService;
+
+    @MockBean
+    private CardService cardService;
+
+    @MockBean
+    private ClovaOCRService clovaOCRService;
+
+    @Test
+    @DisplayName("발급 요청이 정상적으로 처리되는지 테스트(비동기 작업이기 때문에 처리될 것을 의미하는 202 Accepted로 결과 나와야 성공)")
+    public void createCardIssueTest() throws Exception {
+        /*
+        Given: 테스트를 위한 준비
+        */
+        CreateCardIssueRequest request = CreateCardIssueRequest
+                .builder()
+                .cardIssueResidentNo("987654-1234567")
+                .cardIssueEname("ASYNC SEUNGGEON")
+                .cardIssueEmail("guny1117@nate.com")
+                .cardIssueBank("카카오뱅크")
+                .cardIssueAccount("1231321312-231")
+                .cardIssueIsAgree(true)
+                .cardIssueIncome(0)
+                .cardIssueCredit(0)
+                .cardIssueAmountDate(Date.valueOf("2024-08-12"))
+                .cardIssueSource("working")
+                .cardIssueIsHighrisk(true)
+                .cardIssuePurpose("use")
+                .userNo(1L)
+                .cardIssueIsFamily(false)
+                .cardIssueAddress("서울시 관악구")
+                .cardIssuePassword("0001")
+                .build();
+
+        CreateCardIssueResponse createCardIssueResponse = CreateCardIssueResponse.builder()
+                .message("카드 발급 요청이 접수되었습니다.")
+                .status(HttpStatus.ACCEPTED)
+                .build();
+
+        // Mockito 라이브러리를 사용하여 서비스 계층 모의(흉내)
+        Mockito.when(cardIssueService.createPostCardIssue(Mockito.any(CreateCardIssueRequest.class)))
+                .thenReturn(createCardIssueResponse);
+
+        /*
+        When: 테스트 행위를 수행
+        */
+        mockMvc.perform(post("/api/v1/card/apply")
+                        .contentType(MediaType.APPLICATION_JSON) // 직렬화된 문자열을 MockMvc를 사용하여 Post 요청의 content로 사용
+                        .content(objectMapper.writeValueAsString(request))) // request 객체를 json으로 직렬화
+                /*
+                Then: 결과 검증
+                */
+                .andExpect(status().isAccepted()) // 응답 상태 코드가 202 Accepted인지 검증
+                .andExpect(content().json(objectMapper.writeValueAsString(createCardIssueResponse))); // 서버의 응답이 예상과 일치하는지 검증
+    }
+
+    @Test
+    @DisplayName("사용자 번호로 카드 정보 조회 테스트")
+    public void readDetailTest() throws Exception {
+        /*
+        Given: 테스트를 위한 준비
+        */
+        Long userNo = 1L;
+        List<ReadCardResponse> mockResponse = Arrays.asList(
+                ReadCardResponse.builder()
+                        .cardEname("YangSeungGeon")
+                        .cardBank("카카오뱅크")
+                        .cardAccount("123-456-7890")
+                        .cardAmountDate(Date.valueOf("2024-08-12"))
+                        .cardAddress("서울시 관악구")
+                        .cardIsFamily(true)
+                        .build(),
+                ReadCardResponse.builder()
+                        .cardEname("YangSeungGeon")
+                        .cardBank("신한은행")
+                        .cardAccount("098-765-4321")
+                        .cardAmountDate(Date.valueOf("2024-09-12"))
+                        .cardAddress("부산시 해운대구")
+                        .cardIsFamily(false)
+                        .build()
+        );
+
+        // Mockito 라이브러리를 사용하여 서비스 계층 모의(흉내)
+        Mockito.when(cardService.readGetCards(userNo)).thenReturn(mockResponse);
+
+        /*
+        When: 테스트 행위를 수행
+        */
+        mockMvc.perform(get("/api/v1/card/read/{userNo}", userNo)
+                        .contentType(MediaType.APPLICATION_JSON))
+                /*
+                Then: 결과 검증
+                */
+                .andExpect(status().isOk()) // 응답 상태 코드가 200 OK인지 검증
+                .andExpect(content().json(objectMapper.writeValueAsString(mockResponse))); // 서버의 응답이 예상과 일치하는지 검증
+    }
+
+
+}

--- a/src/test/java/com/shinhan/knockknock/repository/CardIssueRepositoryTest.java
+++ b/src/test/java/com/shinhan/knockknock/repository/CardIssueRepositoryTest.java
@@ -1,0 +1,57 @@
+package com.shinhan.knockknock.repository;
+
+import com.shinhan.knockknock.domain.entity.CardIssueEntity;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Date;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional
+public class CardIssueRepositoryTest {
+
+    @Autowired
+    private CardIssueRepository cardIssueRepository;
+
+    @Test
+    @Rollback
+    public void testSaveAndFindById() {
+        // given
+        CardIssueEntity cardIssueEntity = new CardIssueEntity();
+        cardIssueEntity.setCardIssueResidentNo("987654-1234567");
+        cardIssueEntity.setCardIssueEname("ASYNC SEUNGGEON");
+        cardIssueEntity.setCardIssueEmail("guny1117@nate.com");
+        cardIssueEntity.setCardIssueBank("카카오뱅크");
+        cardIssueEntity.setCardIssueAccount("1231321312-231");
+        cardIssueEntity.setCardIssueIsAgree(true);
+        cardIssueEntity.setCardIssueIncome(500);
+        cardIssueEntity.setCardIssueCredit(500);
+        cardIssueEntity.setCardIssueAmountDate(Date.valueOf("2024-08-12"));
+        cardIssueEntity.setCardIssueSource("월급");
+        cardIssueEntity.setCardIssueIsHighrisk(true);
+        cardIssueEntity.setCardIssuePurpose("생활비");
+        cardIssueEntity.setUserNo(1L);
+        cardIssueEntity.setCardIssueIsFamily(false);
+        cardIssueEntity.setCardIssueAddress("서울시 관악구");
+
+        // when
+        CardIssueEntity savedEntity = cardIssueRepository.save(cardIssueEntity);
+        Long generatedId = savedEntity.getCardIssueNo(); // 저장된 엔티티에서 ID를 가져옴
+        Optional<CardIssueEntity> foundEntity = cardIssueRepository.findById(generatedId);
+
+        // then
+        assertTrue(foundEntity.isPresent());
+        assertEquals("987654-1234567", foundEntity.get().getCardIssueResidentNo());
+        assertEquals("ASYNC SEUNGGEON", foundEntity.get().getCardIssueEname());
+        assertEquals("guny1117@nate.com", foundEntity.get().getCardIssueEmail());
+    }
+}

--- a/src/test/java/com/shinhan/knockknock/repository/CardRepositoryTest.java
+++ b/src/test/java/com/shinhan/knockknock/repository/CardRepositoryTest.java
@@ -1,0 +1,79 @@
+package com.shinhan.knockknock.repository;
+
+import com.shinhan.knockknock.domain.entity.CardEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Date;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional
+public class CardRepositoryTest {
+
+    @Autowired
+    private CardRepository cardRepository;
+
+    // 데이터베이스 테스트 전 초기화
+    @BeforeEach
+    public void setUp() {
+        cardRepository.deleteAll();
+    }
+
+    @Test
+    @Rollback
+    public void FindByUserNoTest() {
+        /*
+        given
+         */
+        Long userNo = 1L;
+
+        CardEntity cardEntity1 = new CardEntity();
+        cardEntity1.setCardAccount("123456789");
+        cardEntity1.setCardAddress("서울시 강남구");
+        cardEntity1.setCardAmountDate(Date.valueOf("2024-12-01"));
+        cardEntity1.setCardBank("Shinhan");
+        cardEntity1.setCardCvc("123");
+        cardEntity1.setCardEname("Hong Gil-dong");
+        cardEntity1.setCardExpiredate(Date.valueOf("2029-12-01"));
+        cardEntity1.setCardIsfamily(false);
+        cardEntity1.setCardIssueNo(1L);
+        cardEntity1.setCardNo("1111-2222-3333-4444");
+        cardEntity1.setCardPassword("1234");
+        cardEntity1.setUserNo(userNo);
+        cardRepository.save(cardEntity1);
+
+        CardEntity cardEntity2 = new CardEntity();
+        cardEntity2.setCardAccount("987654321");
+        cardEntity2.setCardAddress("서울시 서초구");
+        cardEntity2.setCardAmountDate(Date.valueOf("2024-11-01"));
+        cardEntity2.setCardBank("Kookmin");
+        cardEntity2.setCardCvc("321");
+        cardEntity2.setCardEname("Kim Yuna");
+        cardEntity2.setCardExpiredate(Date.valueOf("2029-11-01"));
+        cardEntity2.setCardIsfamily(false);
+        cardEntity2.setCardIssueNo(2L);
+        cardEntity2.setCardNo("5555-6666-7777-8888");
+        cardEntity2.setCardPassword("5678");
+        cardEntity2.setUserNo(userNo);
+        cardRepository.save(cardEntity2);
+
+        /*
+         when
+         */
+        List<CardEntity> cards = cardRepository.findByUserNo(userNo);
+
+        /*
+         then
+         */
+        assertEquals(2, cards.size());
+    }
+}

--- a/src/test/java/com/shinhan/knockknock/service/CardIssueServiceImplTest.java
+++ b/src/test/java/com/shinhan/knockknock/service/CardIssueServiceImplTest.java
@@ -1,0 +1,75 @@
+package com.shinhan.knockknock.service;
+
+import com.shinhan.knockknock.domain.dto.CreateCardIssueRequest;
+import com.shinhan.knockknock.domain.dto.CreateCardIssueResponse;
+import com.shinhan.knockknock.domain.entity.CardIssueEntity;
+import com.shinhan.knockknock.repository.CardIssueRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import java.sql.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+
+@SpringJUnitConfig(CardIssueServiceImpl.class)
+public class CardIssueServiceImplTest {
+
+    @Autowired
+    private CardIssueServiceImpl cardIssueService;
+
+    @MockBean
+    private CardIssueRepository cardIssueRepository;
+
+    @MockBean
+    private CardServiceImpl cardService;
+
+    @Test
+    @DisplayName("createPostCardIssue 메소드 테스트")
+    public void createPostCardIssueTest() {
+        /*
+        Given: 테스트 준비
+        */
+        CreateCardIssueRequest request = CreateCardIssueRequest
+                .builder()
+                .cardIssueResidentNo("987654-1234567")
+                .cardIssueEname("ASYNC SEUNGGEON")
+                .cardIssueEmail("guny1117@nate.com")
+                .cardIssueBank("카카오뱅크")
+                .cardIssueAccount("1231321312-231")
+                .cardIssueIsAgree(true)
+                .cardIssueIncome(0)
+                .cardIssueCredit(0)
+                .cardIssueAmountDate(Date.valueOf("2024-08-12"))
+                .cardIssueSource("working")
+                .cardIssueIsHighrisk(true)
+                .cardIssuePurpose("use")
+                .userNo(1L)
+                .cardIssueIsFamily(false)
+                .cardIssueAddress("서울시 관악구")
+                .cardIssuePassword("0001")
+                .build();
+
+        CardIssueEntity cardIssueEntity = CardIssueEntity.builder().build();
+        Mockito.when(cardIssueRepository.save(any(CardIssueEntity.class))).thenReturn(cardIssueEntity);
+
+        /*
+        When: 테스트 수행
+        */
+        CreateCardIssueResponse response = cardIssueService.createPostCardIssue(request);
+
+        /*
+        Then: 결과 검증
+        */
+        assertEquals("카드 발급 요청이 접수되었습니다.", response.getMessage());
+        assertEquals(HttpStatus.ACCEPTED, response.getStatus());
+
+        Mockito.verify(cardIssueRepository).save(any(CardIssueEntity.class));
+        Mockito.verify(cardService).scheduleCreatePostCard(cardIssueEntity, "0001");
+    }
+}

--- a/src/test/java/com/shinhan/knockknock/service/CardServiceImplTest.java
+++ b/src/test/java/com/shinhan/knockknock/service/CardServiceImplTest.java
@@ -1,0 +1,130 @@
+package com.shinhan.knockknock.service;
+
+import com.shinhan.knockknock.domain.dto.CreateCardIssueResponse;
+import com.shinhan.knockknock.domain.dto.ReadCardResponse;
+import com.shinhan.knockknock.domain.entity.CardEntity;
+import com.shinhan.knockknock.domain.entity.CardIssueEntity;
+import com.shinhan.knockknock.repository.CardRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.scheduling.annotation.AsyncResult;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import java.sql.Date;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+
+@SpringJUnitConfig(CardServiceImpl.class)
+public class CardServiceImplTest {
+
+    @Autowired
+    private CardServiceImpl cardService;
+
+    @MockBean
+    private CardRepository cardRepository;
+
+    @Test
+    @DisplayName("scheduleCreatePostCard 메소드 테스트")
+    public void scheduleCreatePostCardTest() throws Exception {
+        /*
+        Given: 테스트 준비
+        */
+        CardIssueEntity cardIssueEntity = CardIssueEntity.builder().build();
+        String password = "0001";
+
+        /*
+        When: 테스트 수행
+        */
+        CompletableFuture<CreateCardIssueResponse> future = new AsyncResult<>(cardService.createPostCard(cardIssueEntity, password)).completable();
+        future.get(); // 비동기 업무가 완료될 때까지 테스트
+
+        /*
+        Then: 결과 검증
+        */
+        Mockito.verify(cardRepository, Mockito.times(1)).save(any(CardEntity.class));
+    }
+
+    @Test
+    @DisplayName("createPostCard 메소드 테스트")
+    public void createPostCardTest() {
+        /*
+        Given: 테스트 준비
+        */
+        CardIssueEntity cardIssueEntity = CardIssueEntity.builder()
+                .cardIssueEname("ASYNC SEUNGGEON")
+                .cardIssueBank("카카오뱅크")
+                .cardIssueAccount("1231321312-231")
+                .cardIssueAmountDate(Date.valueOf("2024-08-12"))
+                .build();
+
+        Mockito.when(cardRepository.save(any(CardEntity.class)))
+                .thenReturn(CardEntity.builder().build());
+
+        /*
+        When: 테스트 수행
+        */
+        CreateCardIssueResponse response = cardService.createPostCard(cardIssueEntity, "0001");
+
+        /*
+        Then: 결과 검증
+        */
+        assertEquals("카드 발급 성공", response.getMessage());
+        assertEquals(HttpStatus.CREATED, response.getStatus());
+
+        // Verify the interaction with the mock repository
+        Mockito.verify(cardRepository).save(any(CardEntity.class));
+    }
+
+    @Test
+    @DisplayName("readGetCards 메소드 테스트")
+    public void readGetCardsTest() {
+        /*
+        Given: 테스트 준비
+        */
+        Long userNo = 1L;
+        List<CardEntity> cardEntities = Arrays.asList(
+                CardEntity.builder()
+                        .cardEname("YangSeungGeon")
+                        .cardBank("카카오뱅크")
+                        .cardAccount("123-456-7890")
+                        .cardAmountDate(Date.valueOf("2024-08-12"))
+                        .cardExpiredate(Date.valueOf(LocalDate.now().plusYears(5)))
+                        .cardIsfamily(true)
+                        .build(),
+                CardEntity.builder()
+                        .cardEname("YangSeungGeon")
+                        .cardBank("신한은행")
+                        .cardAccount("098-765-4321")
+                        .cardAmountDate(Date.valueOf("2024-09-12"))
+                        .cardExpiredate(Date.valueOf(LocalDate.now().plusYears(5)))
+                        .cardIsfamily(false)
+                        .build()
+        );
+
+        Mockito.when(cardRepository.findByUserNo(userNo)).thenReturn(cardEntities);
+
+        /*
+        When: 테스트 수행
+        */
+        List<ReadCardResponse> response = cardService.readGetCards(userNo);
+
+        /*
+        Then: 결과 검증
+        */
+        assertEquals(2, response.size());
+        assertEquals("YangSeungGeon", response.get(0).getCardEname());
+        assertEquals("카카오뱅크", response.get(0).getCardBank());
+
+        // Verify the interaction with the mock repository
+        Mockito.verify(cardRepository).findByUserNo(userNo);
+    }
+}


### PR DESCRIPTION
## 🌟(#53 ) 카드 조회 예외처리


## ✍️내용
- 카드 발급 신청을 하지 않았을 땐 "발급된 카드가 없습니다"를 응답
- 카드 발급 신청하고 대기중일 땐 "카드 발급 대기중입니다"를 응답
- 발급된 카드가 있는 경우 발급된 카드 정보를 응답

## 📸스크린샷
- 발급 신청 전
<img width="541" alt="image" src="https://github.com/user-attachments/assets/914605d6-2e87-49a3-8e50-fa63800d891b">


- 발급 신청 후 발급 대기중
<img width="527" alt="image" src="https://github.com/user-attachments/assets/f32e5ef7-75fa-414c-a0e1-b9fda49f34d1">


- 발급 완료
<img width="553" alt="image" src="https://github.com/user-attachments/assets/40cc3ecc-43b1-4364-ae8b-dc3b1c744f1c">



## 🎈참고사항

## ✅PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [x] main 브랜치에 PR 요청 인지 develop 브랜치에 PR 요청 인지 확인했습니다.