### PR TITLE
🌟(#63 ) 알림서비스 구현

### DIFF
--- a/src/main/java/com/shinhan/knockknock/controller/CardController.java
+++ b/src/main/java/com/shinhan/knockknock/controller/CardController.java
@@ -1,5 +1,6 @@
 package com.shinhan.knockknock.controller;
 
+import com.shinhan.knockknock.auth.JwtProvider;
 import com.shinhan.knockknock.domain.dto.CreateCardIssueRequest;
 import com.shinhan.knockknock.domain.dto.CreateCardIssueResponse;
 import com.shinhan.knockknock.domain.dto.ReadCardResponse;
@@ -8,7 +9,7 @@ import com.shinhan.knockknock.service.CardService;
 import com.shinhan.knockknock.service.ClovaOCRService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 import org.springframework.web.bind.annotation.*;
@@ -18,15 +19,14 @@ import java.util.List;
 @CrossOrigin
 @RestController
 @RequestMapping("/api/v1/card")
+@RequiredArgsConstructor
 @Tag(name = "카드", description = "카드 발급, 조회 API")
 public class CardController {
 
-    @Autowired
-    CardIssueService cardIssueService;
-    @Autowired
-    CardService cardService;
-    @Autowired
-    ClovaOCRService clovaOCRService;
+    private final CardIssueService cardIssueService;
+    private final CardService cardService;
+    private final ClovaOCRService clovaOCRService;
+    private final JwtProvider jwtProvider;
 
     /*
     200 OK: 서버가 요청을 성공적으로 처리했으며, 그 결과를 클라이언트에게 반환하고 있다는 것을 의미
@@ -35,9 +35,9 @@ public class CardController {
      */
     @Operation(summary = "카드 발급", description= "발급 신청 폼 받고 1분 후 카드 발급")
     @PostMapping
-    @ResponseStatus(HttpStatus.ACCEPTED) // 비동기 테스트 위해서 ACCEPTED로 가도록 추가
-    public CreateCardIssueResponse createCardIssue(@RequestBody CreateCardIssueRequest request) {
-        CreateCardIssueResponse createCardIssueResponse = cardIssueService.createPostCardIssue(request);
+    @ResponseStatus(HttpStatus.ACCEPTED) // 비동기 테스트 ACCEPTED
+    public CreateCardIssueResponse createCardIssue(@RequestHeader("Authorization") String header , @RequestBody CreateCardIssueRequest request) {
+        CreateCardIssueResponse createCardIssueResponse = cardIssueService.createPostCardIssue(request, jwtProvider.getUserNoFromHeader(header));
         return createCardIssueResponse;
     }
 

--- a/src/main/java/com/shinhan/knockknock/controller/CardController.java
+++ b/src/main/java/com/shinhan/knockknock/controller/CardController.java
@@ -37,6 +37,7 @@ public class CardController {
     @PostMapping
     @ResponseStatus(HttpStatus.ACCEPTED) // 비동기 테스트 ACCEPTED
     public CreateCardIssueResponse createCardIssue(@RequestHeader("Authorization") String header , @RequestBody CreateCardIssueRequest request) {
+        request.setCardIssueEname(cardIssueService.mergeName(request));
         CreateCardIssueResponse createCardIssueResponse = cardIssueService.createPostCardIssue(request, jwtProvider.getUserNoFromHeader(header));
         return createCardIssueResponse;
     }

--- a/src/main/java/com/shinhan/knockknock/controller/NotificationController.java
+++ b/src/main/java/com/shinhan/knockknock/controller/NotificationController.java
@@ -1,5 +1,7 @@
 package com.shinhan.knockknock.controller;
 
+import com.shinhan.knockknock.auth.JwtProvider;
+import com.shinhan.knockknock.domain.entity.NotificationEntity;
 import com.shinhan.knockknock.service.NotificationServiceImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -8,6 +10,8 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.util.Map;
+
 @CrossOrigin
 @RestController
 @RequestMapping("/api/v1/notification")
@@ -15,20 +19,35 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @RequiredArgsConstructor
 public class NotificationController {
     private final NotificationServiceImpl notificationService;
+    private final JwtProvider jwtProvider;
 
     // 알림 구독
-    @Operation(summary = "알림 구독", description= "구독 메서드를 수행해야 알림 받을 수 있어요")
-    @GetMapping(value = "/{id}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter subscribe(@PathVariable Long id) { // emitter 연결 응답 객체를 반환
-        return notificationService.subscribe(id); // 이벤트 객체 생성: [userNo=1] 응답
+    @Operation(summary = "알림 구독", description= "구독 메서드를 수행해야 알림 받을 수 있어요(항상 받을 준비해야해요)")
+    @GetMapping(value = "/{userNo}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(@PathVariable Long userNo) {
+        return notificationService.subscribe(userNo);
+    }
+
+    // 알림 구독 JWT 용
+    @Operation(summary = "JWT 사용 알림 구독", description= "jwt 이용한 알림 구독 (swagger에서 알림 테스트 불가)")
+    @GetMapping(produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribeNotificationByJwt(@RequestHeader("Authorization") String header){
+        return notificationService.subscribe(jwtProvider.getUserNoFromHeader(header));
     }
 
     // 알림 전송 테스트 메서드
     @Operation(summary = "알림 전송 테스트 메서드", description= "알림 전송 테스트 메서드")
-    @PostMapping("/send-data/1")
-    public String sendDataTest() {
-        notificationService.notify(1L, "알림");
+    @PostMapping
+    public String sendDataTest(@RequestBody Map<String, Long> payload) {
+        Long userNo = payload.get("userNo");
+        NotificationEntity notificationEntity = NotificationEntity.builder()
+                .notificationCategory("알림")
+                .notificationTitle("알림 전송 테스트")
+                .notificationContent("알림 전송 테스트 성공")
+                .userNo(userNo)
+                .build();
+
+        notificationService.notify(notificationEntity);
         return "notification success";
     }
-    // 나중엔 서버안에서 고정값을 동적으로 변경하여 알림을 사용할 때 userNo와 메시지를 추가해서 사용하도록
 }

--- a/src/main/java/com/shinhan/knockknock/domain/dto/CreateCardIssueRequest.java
+++ b/src/main/java/com/shinhan/knockknock/domain/dto/CreateCardIssueRequest.java
@@ -13,7 +13,6 @@ import java.sql.Timestamp;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateCardIssueRequest {
-    private Long cardIssueNo;
     private String cardIssueResidentNo;
     private String cardIssueEname;
     private String cardIssueEmail;
@@ -26,8 +25,6 @@ public class CreateCardIssueRequest {
     private String cardIssueSource;
     private boolean cardIssueIsHighrisk;
     private String cardIssuePurpose;
-    private Timestamp cardIssueIssueDate;
-    private Long userNo;
     private String cardIssueAddress;
     private boolean cardIssueIsFamily;
     private String cardIssuePassword;

--- a/src/main/java/com/shinhan/knockknock/domain/dto/CreateCardIssueRequest.java
+++ b/src/main/java/com/shinhan/knockknock/domain/dto/CreateCardIssueRequest.java
@@ -13,17 +13,19 @@ import java.sql.Timestamp;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateCardIssueRequest {
-    private String cardIssueResidentNo;
+    //private String cardIssueResidentNo;
+    private String cardIssueFirstEname;
+    private String cardIssueLastEname;
     private String cardIssueEname;
     private String cardIssueEmail;
     private String cardIssueBank;
     private String cardIssueAccount;
     private boolean cardIssueIsAgree;
-    private int cardIssueIncome;
-    private int cardIssueCredit;
-    private Date cardIssueAmountDate;
+    private String cardIssueIncome;
+    private String cardIssueCredit;
+    private String cardIssueAmountDate;
     private String cardIssueSource;
-    private boolean cardIssueIsHighrisk;
+    private String cardIssueIsHighrisk;
     private String cardIssuePurpose;
     private String cardIssueAddress;
     private boolean cardIssueIsFamily;

--- a/src/main/java/com/shinhan/knockknock/domain/dto/ReadCardResponse.java
+++ b/src/main/java/com/shinhan/knockknock/domain/dto/ReadCardResponse.java
@@ -19,7 +19,7 @@ public class ReadCardResponse {
     //private int cardPassword;
     private String cardBank;
     private String cardAccount;
-    private Date cardAmountDate;
+    private String cardAmountDate;
     private String cardExpiredate;
     //private Long issueNo;
     //private Long userNo;

--- a/src/main/java/com/shinhan/knockknock/domain/dto/ReadNotificationResponse.java
+++ b/src/main/java/com/shinhan/knockknock/domain/dto/ReadNotificationResponse.java
@@ -1,0 +1,20 @@
+package com.shinhan.knockknock.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.sql.Date;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class ReadNotificationResponse {
+    private Long notificationNo;
+    private String notificationCategory;
+    private String notificationTitle;
+    private String notificationContent;
+    private String notificationDateTime;
+    private boolean notificationIsCheck;
+    private Long userNo;
+}

--- a/src/main/java/com/shinhan/knockknock/domain/entity/CardEntity.java
+++ b/src/main/java/com/shinhan/knockknock/domain/entity/CardEntity.java
@@ -48,7 +48,7 @@ public class CardEntity {
 
     @Column(name= "card_amountdate")
     @NotNull
-    private Date cardAmountDate;
+    private String cardAmountDate;
 
     @Column(name= "card_expiredate")
     @NotNull

--- a/src/main/java/com/shinhan/knockknock/domain/entity/CardIssueEntity.java
+++ b/src/main/java/com/shinhan/knockknock/domain/entity/CardIssueEntity.java
@@ -24,9 +24,9 @@ public class CardIssueEntity {
     @Column(name= "cardissue_no")
     private Long cardIssueNo;
 
-    @Column(name= "cardissue_residentno", length = 50)
-    @NotNull
-    private String cardIssueResidentNo;
+    //@Column(name= "cardissue_residentno", length = 50)
+    //@NotNull
+    //private String cardIssueResidentNo;
 
     @Column(name= "cardissue_ename", length = 50)
     @NotNull
@@ -47,17 +47,17 @@ public class CardIssueEntity {
     @NotNull
     private boolean cardIssueIsAgree;
 
-    @Column(name= "cardissue_income")
+    @Column(name= "cardissue_income", length = 50)
     @NotNull
-    private int cardIssueIncome;
+    private String cardIssueIncome;
 
-    @Column(name= "cardissue_credit")
+    @Column(name= "cardissue_credit", length = 50)
     @NotNull
-    private int cardIssueCredit;
+    private String cardIssueCredit;
 
     @Column(name= "cardissue_amountdate")
     @NotNull
-    private Date cardIssueAmountDate;
+    private String cardIssueAmountDate;
 
     @Column(name= "cardissue_source")
     @NotNull
@@ -65,13 +65,13 @@ public class CardIssueEntity {
 
     @Column(name= "cardissue_ishighrisk")
     @NotNull
-    private boolean cardIssueIsHighrisk;
+    private String cardIssueIsHighrisk;
 
     @Column(name= "cardissue_purpose")
     @NotNull
     private String cardIssuePurpose;
 
-    @Column(name= "cardissue_issuedate")
+    @Column(name= "cardissue_issuedate", length = 50)
     @CreationTimestamp
     private Timestamp cardIssueIssueDate;
 

--- a/src/main/java/com/shinhan/knockknock/domain/entity/NotificationEntity.java
+++ b/src/main/java/com/shinhan/knockknock/domain/entity/NotificationEntity.java
@@ -8,6 +8,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 
+import java.sql.Date;
 import java.sql.Timestamp;
 
 @Data
@@ -27,12 +28,11 @@ public class NotificationEntity {
     private String notificationTitle;
     private String notificationContent;
 
-    @CreationTimestamp
     @Column(name="notification_datetime")
     @NotNull
-    private Timestamp notificationDateTime;
+    private Date notificationDateTime;
 
-    @Column(name="notification_ischeck")
+    @Column(name="notification_ischeck", columnDefinition = "boolean default false")
     @NotNull
     private boolean notificationIsCheck;
     private Long userNo;

--- a/src/main/java/com/shinhan/knockknock/repository/NotificationRepository.java
+++ b/src/main/java/com/shinhan/knockknock/repository/NotificationRepository.java
@@ -1,0 +1,7 @@
+package com.shinhan.knockknock.repository;
+
+import com.shinhan.knockknock.domain.entity.NotificationEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<NotificationEntity, Long> {
+}

--- a/src/main/java/com/shinhan/knockknock/service/CardIssueService.java
+++ b/src/main/java/com/shinhan/knockknock/service/CardIssueService.java
@@ -6,7 +6,7 @@ import com.shinhan.knockknock.domain.entity.CardIssueEntity;
 public interface CardIssueService {
 
     // 카드 발급 요청
-    public CreateCardIssueResponse createPostCardIssue(CreateCardIssueRequest request);
+    public CreateCardIssueResponse createPostCardIssue(CreateCardIssueRequest request, Long userNo);
 
     // DTO -> Entity
     default CardIssueEntity transformDTOToEntity(CreateCardIssueRequest request){
@@ -24,7 +24,6 @@ public interface CardIssueService {
                 .cardIssueSource(request.getCardIssueSource())
                 .cardIssueIsHighrisk(request.isCardIssueIsHighrisk())
                 .cardIssuePurpose(request.getCardIssuePurpose())
-                .userNo(request.getUserNo())
                 .cardIssueIsFamily(request.isCardIssueIsFamily())
                 .cardIssueAddress(request.getCardIssueAddress())
                 .build();

--- a/src/main/java/com/shinhan/knockknock/service/CardIssueService.java
+++ b/src/main/java/com/shinhan/knockknock/service/CardIssueService.java
@@ -8,11 +8,14 @@ public interface CardIssueService {
     // 카드 발급 요청
     public CreateCardIssueResponse createPostCardIssue(CreateCardIssueRequest request, Long userNo);
 
+    // 영문 이름 처리
+    public String mergeName(CreateCardIssueRequest cardIssueEntity);
+
     // DTO -> Entity
     default CardIssueEntity transformDTOToEntity(CreateCardIssueRequest request){
 
         CardIssueEntity cardIssueEntity = CardIssueEntity.builder()
-                .cardIssueResidentNo(request.getCardIssueResidentNo())
+                //.cardIssueResidentNo(request.getCardIssueResidentNo())
                 .cardIssueEname(request.getCardIssueEname())
                 .cardIssueEmail(request.getCardIssueEmail())
                 .cardIssueBank(request.getCardIssueBank())
@@ -22,7 +25,7 @@ public interface CardIssueService {
                 .cardIssueCredit(request.getCardIssueCredit())
                 .cardIssueAmountDate(request.getCardIssueAmountDate())
                 .cardIssueSource(request.getCardIssueSource())
-                .cardIssueIsHighrisk(request.isCardIssueIsHighrisk())
+                .cardIssueIsHighrisk(request.getCardIssueIsHighrisk())
                 .cardIssuePurpose(request.getCardIssuePurpose())
                 .cardIssueIsFamily(request.isCardIssueIsFamily())
                 .cardIssueAddress(request.getCardIssueAddress())

--- a/src/main/java/com/shinhan/knockknock/service/CardIssueServiceImpl.java
+++ b/src/main/java/com/shinhan/knockknock/service/CardIssueServiceImpl.java
@@ -34,4 +34,11 @@ public class CardIssueServiceImpl implements CardIssueService {
                 .status(HttpStatus.ACCEPTED)
                 .build();
     }
+
+    @Override
+    public String mergeName(CreateCardIssueRequest request){
+        return request.getCardIssueEname() != null
+                ? request.getCardIssueEname() 
+                : request.getCardIssueFirstEname() + " " + request.getCardIssueLastEname();
+    }
 }

--- a/src/main/java/com/shinhan/knockknock/service/CardIssueServiceImpl.java
+++ b/src/main/java/com/shinhan/knockknock/service/CardIssueServiceImpl.java
@@ -17,12 +17,14 @@ public class CardIssueServiceImpl implements CardIssueService {
     CardService cardService;
 
     @Override
-    public CreateCardIssueResponse createPostCardIssue(CreateCardIssueRequest request) {
+    public CreateCardIssueResponse createPostCardIssue(CreateCardIssueRequest request, Long userNo) {
 
         String password = request.getCardIssuePassword();
 
-        // CardIssueEntity 생성
-        CardIssueEntity cardIssueEntity = cardIssueRepository.save(transformDTOToEntity(request));
+        // CardIssueEntity에 token에서 가져온 userNo 붙이고 생성
+        CardIssueEntity cardIssueEntity = transformDTOToEntity(request);
+        cardIssueEntity.setUserNo(userNo);
+        cardIssueRepository.save(cardIssueEntity);
 
         // 1분 후에 카드 발급 수행
         cardService.scheduleCreatePostCard(cardIssueEntity, password);

--- a/src/main/java/com/shinhan/knockknock/service/NotificationService.java
+++ b/src/main/java/com/shinhan/knockknock/service/NotificationService.java
@@ -1,10 +1,29 @@
 package com.shinhan.knockknock.service;
 
+import com.shinhan.knockknock.domain.dto.ReadNotificationResponse;
+import com.shinhan.knockknock.domain.entity.NotificationEntity;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 public interface NotificationService {
     SseEmitter subscribe(Long userNo);
-    void notify(Long userNo, Object event);
-    void sendToClient(Long userNo, Object data);
+    void notify(NotificationEntity notificationEntity);
+    void sendToClient(NotificationEntity notificationEntity);
     SseEmitter createEmitter(Long userNo);
+
+    // Entity -> DTO
+    default ReadNotificationResponse transformEntityToDTO(NotificationEntity notificationEntity) {
+        ReadNotificationResponse readNotificationResponse = ReadNotificationResponse
+                .builder()
+                .notificationNo(notificationEntity.getNotificationNo())
+                .notificationCategory(notificationEntity.getNotificationCategory())
+                .notificationTitle(notificationEntity.getNotificationTitle())
+                .notificationContent(notificationEntity.getNotificationContent())
+                .notificationDateTime(String.valueOf(notificationEntity.getNotificationDateTime()))
+                .notificationIsCheck(notificationEntity.isNotificationIsCheck())
+                .userNo(notificationEntity.getUserNo())
+                .build();
+
+        return readNotificationResponse;
+    }
+
 }

--- a/src/main/resources/static/Notification.html
+++ b/src/main/resources/static/Notification.html
@@ -8,8 +8,12 @@
 <body>
 <h1>Notification Example</h1>
 
-<!-- Button to subscribe as user 1 -->
-<button id="subscribe-btn">Subscribe as User 1</button>
+<!-- Input field to enter user number -->
+<label for="userNo">userNo입력:</label>
+<input type="number" id="userNo" name="userNo" min="1" required>
+
+<!-- Button to subscribe -->
+<button id="subscribe-btn">Subscribe</button>
 
 <!-- Notification list -->
 <div id="notifications" style="display:none;">
@@ -22,29 +26,36 @@
 <script>
     let eventSource;
 
-    // 1. 구독 버튼
     document.getElementById('subscribe-btn').addEventListener('click', function() {
-        // userNo로 구독을 만들어야 함
-        eventSource = new EventSource('http://localhost:9090/api/v1/notification/1');
+        const userNo = document.getElementById('userNo').value;
 
-        // sse 이벤틑 듣기
-        eventSource.addEventListener('userNo1', event => {
-            console.log('Received event:', event.data);
-            const notificationList = document.getElementById('notification-list');
-            const newNotification = document.createElement('li');
-            newNotification.textContent = event.data;
-            notificationList.appendChild(newNotification);
-        });
+        if (userNo) {
+            // userNo로 구독 (EventSource) 객체 생성 필수
+            eventSource = new EventSource(`http://localhost:9090/api/v1/notification/${userNo}`);
 
-        // Handle connection errors
-        eventSource.onerror = function() {
-            console.error('Connection error occurred.');
-            eventSource.close();
-        };
+            // sse이벤트(알림) 처리
+            const eventName = `userNotification_${userNo}`;
+            eventSource.addEventListener(eventName, event => {
+                console.log('Received event:', event.data);
+                const notificationList = document.getElementById('notification-list');
+                const newNotification = document.createElement('li');
+                newNotification.textContent = event.data;
+                notificationList.appendChild(newNotification);
+            });
 
-        document.getElementById('subscribe-btn').style.display = 'none';
-        document.getElementById('notifications').style.display = 'block';
+            // 에러 처리
+            eventSource.onerror = function() {
+                console.error('Connection error occurred.');
+                eventSource.close();
+            };
+
+            document.getElementById('subscribe-btn').style.display = 'none';
+            document.getElementById('notifications').style.display = 'block';
+        } else {
+            alert('Please enter a valid User Number.');
+        }
     });
 </script>
+
 </body>
 </html>

--- a/src/test/java/com/shinhan/knockknock/controller/CardControllerTest.java
+++ b/src/test/java/com/shinhan/knockknock/controller/CardControllerTest.java
@@ -85,14 +85,14 @@ public class CardControllerTest {
                 .build();
 
         // Mockito 라이브러리를 사용하여 서비스 계층 모의(흉내)
-        Mockito.when(cardIssueService.createPostCardIssue(Mockito.any(CreateCardIssueRequest.class)))
-                .thenReturn(createCardIssueResponse);
+        //Mockito.when(cardIssueService.createPostCardIssue(Mockito.any(CreateCardIssueRequest.class)))
+        //        .thenReturn(createCardIssueResponse);
 
         /*
         When: 테스트 행위를 수행
         */
         mockMvc.perform(post("/api/v1/card")
-                        .with(csrf()) // 이거 뭐임?
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON) // 직렬화된 문자열을 MockMvc를 사용하여 Post 요청의 content로 사용
                         .content(objectMapper.writeValueAsString(request))) // request 객체를 json으로 직렬화
                 /*

--- a/src/test/java/com/shinhan/knockknock/service/CardIssueServiceImplTest.java
+++ b/src/test/java/com/shinhan/knockknock/service/CardIssueServiceImplTest.java
@@ -61,7 +61,7 @@ public class CardIssueServiceImplTest {
         /*
         When: 테스트 수행
         */
-        CreateCardIssueResponse response = cardIssueService.createPostCardIssue(request);
+        CreateCardIssueResponse response = cardIssueService.createPostCardIssue(request, 1L);
 
         /*
         Then: 결과 검증


### PR DESCRIPTION
## 🌟(#63 ) 알림서비스 구현


## ✍️내용
- SSE 통신 알림 서비스 구현 완료

## 📸스크린샷
<img width="1469" alt="image" src="https://github.com/user-attachments/assets/f71d8ebf-c251-4d60-a717-55dd68d2f6f5">

## 🎈참고사항
- 알림 필요한 기능에서 아래 예시 코드로 사용하면 해당 사용자에게 알림 가능
// 알림 서비스 수행
        NotificationEntity notificationEntity = NotificationEntity
                .builder()
                .notificationCategory("카테고리")
                .notificationTitle("알림 제목")
                .notificationContent("알림 내용")
                .userNo( 유저번호 ) // jwt에서 따와서
                .build();
        notificationService.notify(notificationEntity);

## ✅PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [x] main 브랜치에 PR 요청 인지 develop 브랜치에 PR 요청 인지 확인했습니다.