### PR TITLE
🌟(#131 ) 소비리포트 구현

### DIFF
--- a/src/main/java/com/shinhan/knockknock/controller/CardController.java
+++ b/src/main/java/com/shinhan/knockknock/controller/CardController.java
@@ -1,12 +1,12 @@
 package com.shinhan.knockknock.controller;
 
 import com.shinhan.knockknock.auth.JwtProvider;
-import com.shinhan.knockknock.domain.dto.CreateCardIssueRequest;
-import com.shinhan.knockknock.domain.dto.CreateCardIssueResponse;
-import com.shinhan.knockknock.domain.dto.ReadCardResponse;
-import com.shinhan.knockknock.service.CardIssueService;
-import com.shinhan.knockknock.service.CardService;
-import com.shinhan.knockknock.service.ClovaOCRService;
+import com.shinhan.knockknock.domain.dto.card.CreateCardIssueRequest;
+import com.shinhan.knockknock.domain.dto.card.CreateCardIssueResponse;
+import com.shinhan.knockknock.domain.dto.card.ReadCardResponse;
+import com.shinhan.knockknock.service.card.CardIssueService;
+import com.shinhan.knockknock.service.card.CardService;
+import com.shinhan.knockknock.service.card.ClovaOCRService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/shinhan/knockknock/controller/ConsumptionController.java
+++ b/src/main/java/com/shinhan/knockknock/controller/ConsumptionController.java
@@ -1,0 +1,29 @@
+package com.shinhan.knockknock.controller;
+
+import com.shinhan.knockknock.auth.JwtProvider;
+import com.shinhan.knockknock.domain.dto.consumption.ReadConsumptionRequest;
+import com.shinhan.knockknock.domain.dto.consumption.ReadConsumptionResponse;
+import com.shinhan.knockknock.service.consumption.ConsumptionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@CrossOrigin
+@RestController
+@RequestMapping("api/v1/consumption")
+@RequiredArgsConstructor
+@Tag(name = "소비리포트", description = "소비리포트 API")
+public class ConsumptionController {
+    private final ConsumptionService consumptionService;
+    private final JwtProvider jwtProvider;
+
+    @Operation(summary = "본인 소비 리포트 조회", description="userNo로 카드번호를 찾고 해당 카드 번호의 조회하고자 하는 월의 소비리포트 조회")
+    @GetMapping
+    public List<ReadConsumptionResponse> ReadConsumption(@RequestHeader("Authorization") String header , ReadConsumptionRequest readConsumptionRequest){
+        Long userNo = jwtProvider.getUserNoFromHeader(header);
+        return consumptionService.readConsumptionReport(userNo, readConsumptionRequest);
+    }
+}

--- a/src/main/java/com/shinhan/knockknock/controller/NotificationController.java
+++ b/src/main/java/com/shinhan/knockknock/controller/NotificationController.java
@@ -1,10 +1,9 @@
 package com.shinhan.knockknock.controller;
 
 import com.shinhan.knockknock.auth.JwtProvider;
-import com.shinhan.knockknock.domain.dto.ReadNotificationResponse;
+import com.shinhan.knockknock.domain.dto.notification.ReadNotificationResponse;
 import com.shinhan.knockknock.domain.entity.NotificationEntity;
-import com.shinhan.knockknock.repository.NotificationRepository;
-import com.shinhan.knockknock.service.NotificationServiceImpl;
+import com.shinhan.knockknock.service.notification.NotificationServiceImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/shinhan/knockknock/controller/NotificationController.java
+++ b/src/main/java/com/shinhan/knockknock/controller/NotificationController.java
@@ -1,7 +1,9 @@
 package com.shinhan.knockknock.controller;
 
 import com.shinhan.knockknock.auth.JwtProvider;
+import com.shinhan.knockknock.domain.dto.ReadNotificationResponse;
 import com.shinhan.knockknock.domain.entity.NotificationEntity;
+import com.shinhan.knockknock.repository.NotificationRepository;
 import com.shinhan.knockknock.service.NotificationServiceImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -10,6 +12,7 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.util.List;
 import java.util.Map;
 
 @CrossOrigin
@@ -49,5 +52,19 @@ public class NotificationController {
 
         notificationService.notify(notificationEntity);
         return "notification success";
+    }
+
+    // 해당 사용자 알림 전체 조회
+    @Operation(summary = "사용자 알림 전체 조회", description= "사용자 알림 전체 조회")
+    @PostMapping("/read")
+    public List<ReadNotificationResponse> readNotifications(@RequestHeader("Authorization") String header){
+        return notificationService.readNotifications(jwtProvider.getUserNoFromHeader(header));
+    }
+
+    // 알림 상세 조회
+    @Operation(summary = "사용자 알림 상세 조회", description="사용자 알림 상세 조회")
+    @GetMapping("/read/{notificationNo}")
+    public ReadNotificationResponse readNotification(@PathVariable("notificationNo") Long notificationNo){
+        return notificationService.readNotification(notificationNo);
     }
 }

--- a/src/main/java/com/shinhan/knockknock/domain/dto/card/CreateCardIssueRequest.java
+++ b/src/main/java/com/shinhan/knockknock/domain/dto/card/CreateCardIssueRequest.java
@@ -1,13 +1,10 @@
-package com.shinhan.knockknock.domain.dto;
+package com.shinhan.knockknock.domain.dto.card;
 
 import com.shinhan.knockknock.domain.entity.RiskEnum;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.sql.Date;
-import java.sql.Timestamp;
 
 @Data
 @Builder

--- a/src/main/java/com/shinhan/knockknock/domain/dto/card/CreateCardIssueResponse.java
+++ b/src/main/java/com/shinhan/knockknock/domain/dto/card/CreateCardIssueResponse.java
@@ -1,4 +1,4 @@
-package com.shinhan.knockknock.domain.dto;
+package com.shinhan.knockknock.domain.dto.card;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/shinhan/knockknock/domain/dto/card/ReadCardResponse.java
+++ b/src/main/java/com/shinhan/knockknock/domain/dto/card/ReadCardResponse.java
@@ -1,11 +1,9 @@
-package com.shinhan.knockknock.domain.dto;
+package com.shinhan.knockknock.domain.dto.card;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.sql.Date;
 
 @Data
 @Builder

--- a/src/main/java/com/shinhan/knockknock/domain/dto/consumption/ReadConsumptionRequest.java
+++ b/src/main/java/com/shinhan/knockknock/domain/dto/consumption/ReadConsumptionRequest.java
@@ -1,0 +1,20 @@
+package com.shinhan.knockknock.domain.dto.consumption;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.sql.Date;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReadConsumptionRequest {
+    @Schema(example = "24-08-01")
+    private Date startDate;
+    @Schema(example = "24-08-31")
+    private Date endDate;
+}

--- a/src/main/java/com/shinhan/knockknock/domain/dto/consumption/ReadConsumptionResponse.java
+++ b/src/main/java/com/shinhan/knockknock/domain/dto/consumption/ReadConsumptionResponse.java
@@ -1,0 +1,18 @@
+package com.shinhan.knockknock.domain.dto.consumption;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReadConsumptionResponse {
+    private Long cardId;
+    private String categoryName;
+    private boolean isFamily;
+    private int totalAmount;
+    private int amount;
+}

--- a/src/main/java/com/shinhan/knockknock/domain/dto/notification/ReadNotificationResponse.java
+++ b/src/main/java/com/shinhan/knockknock/domain/dto/notification/ReadNotificationResponse.java
@@ -1,10 +1,8 @@
-package com.shinhan.knockknock.domain.dto;
+package com.shinhan.knockknock.domain.dto.notification;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-
-import java.sql.Date;
 
 @Data
 @Builder

--- a/src/main/java/com/shinhan/knockknock/repository/CardRepository.java
+++ b/src/main/java/com/shinhan/knockknock/repository/CardRepository.java
@@ -2,9 +2,15 @@ package com.shinhan.knockknock.repository;
 
 import com.shinhan.knockknock.domain.entity.CardEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface CardRepository extends JpaRepository<CardEntity, Long> {
     List<CardEntity> findByUserNo(Long userNo);
+
+    @Query("SELECT c.cardNo FROM CardEntity c WHERE c.userNo = :userNo")
+    List<String> findCardNoByUserNo(@Param("userNo") Long userNo);
+
 }

--- a/src/main/java/com/shinhan/knockknock/repository/ConsumptionRepository.java
+++ b/src/main/java/com/shinhan/knockknock/repository/ConsumptionRepository.java
@@ -1,0 +1,19 @@
+package com.shinhan.knockknock.repository;
+
+import com.shinhan.knockknock.domain.entity.CardHistoryEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.sql.Date;
+import java.util.List;
+
+public interface ConsumptionRepository extends JpaRepository<CardHistoryEntity, Long> {
+    // 카드 번호 목록과 날짜 범위로 카드 이력 조회
+    List<CardHistoryEntity> findCardHistoriesByCard_CardNoInAndCardHistoryApproveBetween(
+            List<String> cardNo,
+            Date startDate,
+            Date endDate
+    );
+}
+
+
+

--- a/src/main/java/com/shinhan/knockknock/repository/NotificationRepository.java
+++ b/src/main/java/com/shinhan/knockknock/repository/NotificationRepository.java
@@ -3,5 +3,8 @@ package com.shinhan.knockknock.repository;
 import com.shinhan.knockknock.domain.entity.NotificationEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface NotificationRepository extends JpaRepository<NotificationEntity, Long> {
+    List<NotificationEntity> findByUserNo(Long userNo);
 }

--- a/src/main/java/com/shinhan/knockknock/service/NotificationService.java
+++ b/src/main/java/com/shinhan/knockknock/service/NotificationService.java
@@ -4,11 +4,16 @@ import com.shinhan.knockknock.domain.dto.ReadNotificationResponse;
 import com.shinhan.knockknock.domain.entity.NotificationEntity;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface NotificationService {
     SseEmitter subscribe(Long userNo);
     void notify(NotificationEntity notificationEntity);
     void sendToClient(NotificationEntity notificationEntity);
     SseEmitter createEmitter(Long userNo);
+    List<ReadNotificationResponse> readNotifications(Long userNo);
+    ReadNotificationResponse readNotification(Long notificationId);
 
     // Entity -> DTO
     default ReadNotificationResponse transformEntityToDTO(NotificationEntity notificationEntity) {

--- a/src/main/java/com/shinhan/knockknock/service/NotificationServiceImpl.java
+++ b/src/main/java/com/shinhan/knockknock/service/NotificationServiceImpl.java
@@ -10,6 +10,8 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
 import java.sql.Date;
+import java.util.List;
+import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
@@ -92,5 +94,30 @@ public class NotificationServiceImpl implements NotificationService {
         emitter.onTimeout(() -> emitterRepository.deleteByUserNo(userNo));
 
         return emitter;
+    }
+
+    /**
+     * 사용자 아이디를 기반으로 알림 전체 조회
+     *
+     * @param userNo - 사용자 아이디.
+     * @return List<ReadNotificationResponse> - 해당 사용자 모든 알림 조회
+     */
+    public List<ReadNotificationResponse> readNotifications(Long userNo){
+        return notificationRepository.findByUserNo(userNo)
+                .stream()
+                .map(this::transformEntityToDTO)
+                .toList();
+    }
+
+    /**
+     * 사용자 아이디를 기반으로 알림 전체 조회
+     *
+     * @param notificationNo - 사용자 아이디.
+     * @return ReadNotificationResponse - 알림 내용 전송
+     */
+    public ReadNotificationResponse readNotification(Long notificationNo){
+        return notificationRepository.findById(notificationNo)
+                .map(this::transformEntityToDTO) // Optional이 비어 있지 않다면 transformEntityToDTO 호출
+                .orElseThrow(() -> new NoSuchElementException("not found for id: " + notificationNo)); // Optional이 비어있을 때 예외 처리
     }
 }

--- a/src/main/java/com/shinhan/knockknock/service/card/CardIssueService.java
+++ b/src/main/java/com/shinhan/knockknock/service/card/CardIssueService.java
@@ -1,7 +1,7 @@
-package com.shinhan.knockknock.service;
+package com.shinhan.knockknock.service.card;
 
-import com.shinhan.knockknock.domain.dto.CreateCardIssueRequest;
-import com.shinhan.knockknock.domain.dto.CreateCardIssueResponse;
+import com.shinhan.knockknock.domain.dto.card.CreateCardIssueRequest;
+import com.shinhan.knockknock.domain.dto.card.CreateCardIssueResponse;
 import com.shinhan.knockknock.domain.entity.CardIssueEntity;
 import com.shinhan.knockknock.domain.entity.RiskEnum;
 

--- a/src/main/java/com/shinhan/knockknock/service/card/CardIssueServiceImpl.java
+++ b/src/main/java/com/shinhan/knockknock/service/card/CardIssueServiceImpl.java
@@ -1,7 +1,7 @@
-package com.shinhan.knockknock.service;
+package com.shinhan.knockknock.service.card;
 
-import com.shinhan.knockknock.domain.dto.CreateCardIssueRequest;
-import com.shinhan.knockknock.domain.dto.CreateCardIssueResponse;
+import com.shinhan.knockknock.domain.dto.card.CreateCardIssueRequest;
+import com.shinhan.knockknock.domain.dto.card.CreateCardIssueResponse;
 import com.shinhan.knockknock.domain.entity.CardIssueEntity;
 import com.shinhan.knockknock.repository.CardIssueRepository;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/shinhan/knockknock/service/card/CardService.java
+++ b/src/main/java/com/shinhan/knockknock/service/card/CardService.java
@@ -1,7 +1,7 @@
-package com.shinhan.knockknock.service;
+package com.shinhan.knockknock.service.card;
 
-import com.shinhan.knockknock.domain.dto.CreateCardIssueResponse;
-import com.shinhan.knockknock.domain.dto.ReadCardResponse;
+import com.shinhan.knockknock.domain.dto.card.CreateCardIssueResponse;
+import com.shinhan.knockknock.domain.dto.card.ReadCardResponse;
 import com.shinhan.knockknock.domain.entity.CardEntity;
 import com.shinhan.knockknock.domain.entity.CardIssueEntity;
 

--- a/src/main/java/com/shinhan/knockknock/service/card/CardServiceImpl.java
+++ b/src/main/java/com/shinhan/knockknock/service/card/CardServiceImpl.java
@@ -1,12 +1,13 @@
-package com.shinhan.knockknock.service;
+package com.shinhan.knockknock.service.card;
 
-import com.shinhan.knockknock.domain.dto.CreateCardIssueResponse;
-import com.shinhan.knockknock.domain.dto.ReadCardResponse;
+import com.shinhan.knockknock.domain.dto.card.CreateCardIssueResponse;
+import com.shinhan.knockknock.domain.dto.card.ReadCardResponse;
 import com.shinhan.knockknock.domain.entity.CardEntity;
 import com.shinhan.knockknock.domain.entity.CardIssueEntity;
 import com.shinhan.knockknock.domain.entity.NotificationEntity;
 import com.shinhan.knockknock.repository.CardIssueRepository;
 import com.shinhan.knockknock.repository.CardRepository;
+import com.shinhan.knockknock.service.notification.NotificationServiceImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.scheduling.annotation.Async;

--- a/src/main/java/com/shinhan/knockknock/service/card/ClovaOCRService.java
+++ b/src/main/java/com/shinhan/knockknock/service/card/ClovaOCRService.java
@@ -1,4 +1,4 @@
-package com.shinhan.knockknock.service;
+package com.shinhan.knockknock.service.card;
 
 import java.io.BufferedReader;
 import java.io.DataOutputStream;

--- a/src/main/java/com/shinhan/knockknock/service/consumption/ConsumptionService.java
+++ b/src/main/java/com/shinhan/knockknock/service/consumption/ConsumptionService.java
@@ -1,0 +1,11 @@
+package com.shinhan.knockknock.service.consumption;
+
+import com.shinhan.knockknock.domain.dto.consumption.ReadConsumptionRequest;
+import com.shinhan.knockknock.domain.dto.consumption.ReadConsumptionResponse;
+
+import java.util.List;
+
+public interface ConsumptionService {
+    public List<String> readCardNoByUserNo(Long userNo);
+    public List<ReadConsumptionResponse> readConsumptionReport(Long userNo, ReadConsumptionRequest readConsumptionRequest);
+}

--- a/src/main/java/com/shinhan/knockknock/service/consumption/ConsumptionServiceImpl.java
+++ b/src/main/java/com/shinhan/knockknock/service/consumption/ConsumptionServiceImpl.java
@@ -1,0 +1,83 @@
+package com.shinhan.knockknock.service.consumption;
+
+import com.shinhan.knockknock.domain.dto.consumption.ReadConsumptionRequest;
+import com.shinhan.knockknock.domain.dto.consumption.ReadConsumptionResponse;
+import com.shinhan.knockknock.domain.entity.CardHistoryEntity;
+import com.shinhan.knockknock.repository.CardRepository;
+import com.shinhan.knockknock.repository.ConsumptionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.sql.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ConsumptionServiceImpl implements ConsumptionService {
+    private final ConsumptionRepository consumptionRepository;
+    private final CardRepository cardRepository;
+
+    // userNo로 cardNo 조회
+    public List<String> readCardNoByUserNo(Long userNo) {
+        return cardRepository.findCardNoByUserNo(userNo);
+    }
+
+    /**
+     * 주어진 사용자 번호와 날짜 범위를 기반으로 월별 소비 리포트를 생성
+     *
+     * @param userNo               사용자 번호
+     * @param readConsumptionRequest 소비 리포트 요청 정보(startDate, endDate)
+     * @return {
+     *     "cardId": 1,
+     *     "categoryName": "교통",
+     *     "totalAmount": 218000,
+     *     "amount": 25000,
+     *     "family": false
+     *   },
+     */
+    public List<ReadConsumptionResponse> readConsumptionReport(Long userNo, ReadConsumptionRequest readConsumptionRequest) {
+        List<String> cardNos = readCardNoByUserNo(userNo);
+        Date startDate = readConsumptionRequest.getStartDate();
+        Date endDate = readConsumptionRequest.getEndDate();
+
+        List<CardHistoryEntity> cardHistories = consumptionRepository
+                .findCardHistoriesByCard_CardNoInAndCardHistoryApproveBetween(cardNos, startDate, endDate);
+
+        // 카테고리별, 카드 번호별로 금액을 합산하여 Map으로 저장
+        Map<String, Map<String, Integer>> categorySumMap = cardHistories.stream()
+                .collect(Collectors.groupingBy(
+                        // 카드 이력의 카테고리 이름을 기준으로 그룹화
+                        cardHistory -> cardHistory.getCardCategory().getCardCategoryName(),
+                        // 각 카테고리 내에서 카드 번호로 다시 그룹화하고, 금액을 합산
+                        Collectors.groupingBy(
+                                cardHistory -> cardHistory.getCard().getCardNo(),
+                                Collectors.summingInt(CardHistoryEntity::getCardHistoryAmount)
+                        )
+                ));
+
+        // 모든 카테고리와 카드에서의 총 소비 금액을 계산
+        int totalAmount = categorySumMap.values().stream()
+                .flatMap(map -> map.values().stream())
+                .mapToInt(Integer::intValue)
+                .sum();
+
+        // 각 카테고리와 카드별로 리포트 생성하고 리스트로 반환
+        return categorySumMap.entrySet().stream()
+                .flatMap(categoryEntry -> categoryEntry.getValue().entrySet().stream()
+                        .map(cardEntry -> ReadConsumptionResponse.builder()
+                                .categoryName(categoryEntry.getKey())
+                                .amount(cardEntry.getValue())
+                                .totalAmount(totalAmount)
+                                .cardId(cardHistories.stream()
+                                        .filter(ch -> ch.getCard().getCardNo().equals(cardEntry.getKey()))
+                                        .findFirst()
+                                        .map(ch -> ch.getCard().getCardId())
+                                        .orElse(null))
+                                .build()
+                        )
+                ).collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/shinhan/knockknock/service/notification/NotificationService.java
+++ b/src/main/java/com/shinhan/knockknock/service/notification/NotificationService.java
@@ -1,11 +1,10 @@
-package com.shinhan.knockknock.service;
+package com.shinhan.knockknock.service.notification;
 
-import com.shinhan.knockknock.domain.dto.ReadNotificationResponse;
+import com.shinhan.knockknock.domain.dto.notification.ReadNotificationResponse;
 import com.shinhan.knockknock.domain.entity.NotificationEntity;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface NotificationService {
     SseEmitter subscribe(Long userNo);

--- a/src/main/java/com/shinhan/knockknock/service/notification/NotificationServiceImpl.java
+++ b/src/main/java/com/shinhan/knockknock/service/notification/NotificationServiceImpl.java
@@ -1,6 +1,6 @@
-package com.shinhan.knockknock.service;
+package com.shinhan.knockknock.service.notification;
 
-import com.shinhan.knockknock.domain.dto.ReadNotificationResponse;
+import com.shinhan.knockknock.domain.dto.notification.ReadNotificationResponse;
 import com.shinhan.knockknock.domain.entity.NotificationEntity;
 import com.shinhan.knockknock.repository.EmitterRepository;
 import com.shinhan.knockknock.repository.NotificationRepository;

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,36 +1,11 @@
-
 /*
- cardissue_tb data
+  Category
  */
-
-INSERT INTO cardissue_tb (
-    cardissue_address,
-    cardissue_ename,
-    cardissue_email,
-    cardissue_bank,
-    cardissue_account,
-    cardissue_isagree,
-    cardissue_income,
-    cardissue_credit,
-    cardissue_amountdate,
-    cardissue_source,
-    cardissue_ishighrisk,
-    cardissue_purpose,
-    user_no,
-    cardissue_isfamily
-) VALUES (
-             '서버 시작 테스트',  -- 주소
-             'YangSeungGeon',         -- 영문 이름
-             '@.@.@.com',  -- 이메일
-             '카카오뱅크',        -- 은행 이름
-             '12345678901234',   -- 계좌 번호
-             true,               -- 동의 여부
-             50000,              -- 연간소득
-             750,                -- 신용 점수
-             '2024-08-10',       -- 결제 일자
-             'working', -- 자금의 원천
-             'HIGHRISK',              -- 고위험 여부
-             'Personal Use',     -- 거래 목적
-             1,                   -- 유저 번호
-            false
-         );
+INSERT INTO cardcategory_tb (cardcategory_name) VALUES ('식비');
+INSERT INTO cardcategory_tb (cardcategory_name) VALUES ('잡화');
+INSERT INTO cardcategory_tb (cardcategory_name) VALUES ('교통');
+INSERT INTO cardcategory_tb (cardcategory_name) VALUES ('생활');
+INSERT INTO cardcategory_tb (cardcategory_name) VALUES ('쇼핑');
+INSERT INTO cardcategory_tb (cardcategory_name) VALUES ('유흥');
+INSERT INTO cardcategory_tb (cardcategory_name) VALUES ('의료');
+INSERT INTO cardcategory_tb (cardcategory_name) VALUES ('기타');

--- a/src/test/java/com/shinhan/knockknock/controller/CardControllerTest.java
+++ b/src/test/java/com/shinhan/knockknock/controller/CardControllerTest.java
@@ -1,12 +1,12 @@
 package com.shinhan.knockknock.controller;
 
 import com.shinhan.knockknock.auth.JwtProvider;
-import com.shinhan.knockknock.domain.dto.CreateCardIssueRequest;
-import com.shinhan.knockknock.domain.dto.CreateCardIssueResponse;
-import com.shinhan.knockknock.domain.dto.ReadCardResponse;
-import com.shinhan.knockknock.service.CardIssueService;
-import com.shinhan.knockknock.service.CardService;
-import com.shinhan.knockknock.service.ClovaOCRService;
+import com.shinhan.knockknock.domain.dto.card.CreateCardIssueRequest;
+import com.shinhan.knockknock.domain.dto.card.CreateCardIssueResponse;
+import com.shinhan.knockknock.domain.dto.card.ReadCardResponse;
+import com.shinhan.knockknock.service.card.CardIssueService;
+import com.shinhan.knockknock.service.card.CardService;
+import com.shinhan.knockknock.service.card.ClovaOCRService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/shinhan/knockknock/service/CardIssueServiceImplTest.java
+++ b/src/test/java/com/shinhan/knockknock/service/CardIssueServiceImplTest.java
@@ -1,10 +1,12 @@
 package com.shinhan.knockknock.service;
 
-import com.shinhan.knockknock.domain.dto.CreateCardIssueRequest;
-import com.shinhan.knockknock.domain.dto.CreateCardIssueResponse;
+import com.shinhan.knockknock.domain.dto.card.CreateCardIssueRequest;
+import com.shinhan.knockknock.domain.dto.card.CreateCardIssueResponse;
 import com.shinhan.knockknock.domain.entity.CardIssueEntity;
 import com.shinhan.knockknock.domain.entity.RiskEnum;
 import com.shinhan.knockknock.repository.CardIssueRepository;
+import com.shinhan.knockknock.service.card.CardIssueServiceImpl;
+import com.shinhan.knockknock.service.card.CardService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/shinhan/knockknock/service/CardServiceImplTest.java
+++ b/src/test/java/com/shinhan/knockknock/service/CardServiceImplTest.java
@@ -1,11 +1,12 @@
 package com.shinhan.knockknock.service;
 
-import com.shinhan.knockknock.domain.dto.CreateCardIssueResponse;
-import com.shinhan.knockknock.domain.dto.ReadCardResponse;
+import com.shinhan.knockknock.domain.dto.card.ReadCardResponse;
 import com.shinhan.knockknock.domain.entity.CardEntity;
 import com.shinhan.knockknock.domain.entity.CardIssueEntity;
 import com.shinhan.knockknock.repository.CardIssueRepository;
 import com.shinhan.knockknock.repository.CardRepository;
+import com.shinhan.knockknock.service.card.CardServiceImpl;
+import com.shinhan.knockknock.service.notification.NotificationServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/shinhan/knockknock/service/NotificationServiceImplTest.java
+++ b/src/test/java/com/shinhan/knockknock/service/NotificationServiceImplTest.java
@@ -3,6 +3,7 @@ package com.shinhan.knockknock.service;
 import com.shinhan.knockknock.domain.entity.NotificationEntity;
 import com.shinhan.knockknock.repository.EmitterRepository;
 import com.shinhan.knockknock.repository.NotificationRepository;
+import com.shinhan.knockknock.service.notification.NotificationServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,7 +17,7 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-class NotificationTest {
+class NotificationServiceImplTest {
 
     @Mock
     private EmitterRepository emitterRepository; // EmitterRepository를 모킹하여 사용


### PR DESCRIPTION
## 🌟(#131 ) 소비리포트 구현


## ✍️내용
- 소비 리포트 구현
- 토큰에서 userNo 가져와서 userNo의 발급된 카드를 찾고 소비내역을 기반으로 소비리포트 생성

## 📸스크린샷
<img width="184" alt="image" src="https://github.com/user-attachments/assets/a7a37c4f-e860-4183-8740-49c01f4e7f09">
<img width="159" alt="image" src="https://github.com/user-attachments/assets/e7a14823-7b14-4871-9258-e17f583e963f">


## 🎈참고사항

## ✅PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [x] main 브랜치에 PR 요청 인지 develop 브랜치에 PR 요청 인지 확인했습니다.