### PR TITLE
🌟(#167) 스케줄러 구현 및 카드 조회 수정

### DIFF
--- a/src/main/java/com/shinhan/knockknock/BackendApplication.java
+++ b/src/main/java/com/shinhan/knockknock/BackendApplication.java
@@ -2,7 +2,9 @@ package com.shinhan.knockknock;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class BackendApplication {
 

--- a/src/main/java/com/shinhan/knockknock/config/SchedulerConfig.java
+++ b/src/main/java/com/shinhan/knockknock/config/SchedulerConfig.java
@@ -1,0 +1,32 @@
+package com.shinhan.knockknock.config;
+
+import com.shinhan.knockknock.domain.entity.NotificationEntity;
+import com.shinhan.knockknock.service.notification.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SchedulerConfig {
+    private final NotificationService notificationService;
+    /*
+        @Scheduled 속성
+        fixedRate: 작업 수행시간과 상관없이 일정 주기마다 메소드를 호출하는 것
+        fixedDelay는 (작업 수행 시간을 포함하여) 작업을 마친 후부터 주기 타이머가 돌아 메소드를 호출
+        initialDelay: 스케줄러에서 메소드가 등록되자마자 수행하는 것이 아닌 초기 지연시간을 설정
+        cron: Cron 표현식을 사용하여 작업을 예약
+     */
+    @Scheduled(fixedDelay = 10000) // 10초
+    public void SchedulerTest(){
+        NotificationEntity notificationEntity = NotificationEntity.builder()
+                .notificationCategory("스케줄러")
+                .notificationTitle("스케줄러 테스트")
+                .notificationContent("스케줄러 테스트")
+                .userNo(1L)
+                .build();
+        notificationService.notify(notificationEntity);
+    }
+}

--- a/src/main/java/com/shinhan/knockknock/repository/CardRepository.java
+++ b/src/main/java/com/shinhan/knockknock/repository/CardRepository.java
@@ -16,4 +16,7 @@ public interface CardRepository extends JpaRepository<CardEntity, Long> {
     @Query("SELECT c FROM CardEntity c WHERE c.userNo = :userNo")
     List<CardEntity> findCardByUserNo(@Param("userNo") Long userNo);
 
+    // 보호자 번호와 가족 카드 여부로 카드 조회
+    @Query("SELECT c FROM CardEntity c WHERE c.userNo = :userNo AND c.cardIsfamily = true")
+    List<CardEntity> findFamilyCardsByUserNo(@Param("userNo") Long userNo);
 }

--- a/src/main/java/com/shinhan/knockknock/repository/MatchRepository.java
+++ b/src/main/java/com/shinhan/knockknock/repository/MatchRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 public interface MatchRepository extends JpaRepository<MatchEntity, Long> {
     Optional<MatchEntity> findByUserProtectorAndUserProtege(UserEntity protector, UserEntity protege);
     Optional<MatchEntity> findByUserProtectorOrUserProtege(UserEntity protector, UserEntity protege);
+    // user_protegeno (피보호자 번호)로 매칭된 user_protectorno (보호자 번호)를 조회
+    Optional<MatchEntity> findByUserProtege_UserNo(Long userProtegeNo);
 }


### PR DESCRIPTION
## 🌟(#167) 스케줄러 구현 및 카드 조회 수정


## ✍️내용
- 매칭테이블 이용하여 보호자가 만든 가족카드를 매칭된 일반 사용자 측에서 조회 가능
- 스케줄러 구현

## 📸스크린샷


## 🎈참고사항

## ✅PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [x] main 브랜치에 PR 요청 인지 develop 브랜치에 PR 요청 인지 확인했습니다.