### PR TITLE
🌟(#174) 이상 징후 알림 구현

### DIFF
--- a/src/main/java/com/shinhan/knockknock/config/SchedulerConfig.java
+++ b/src/main/java/com/shinhan/knockknock/config/SchedulerConfig.java
@@ -1,9 +1,11 @@
 package com.shinhan.knockknock.config;
 
+import com.shinhan.knockknock.domain.entity.CardEntity;
 import com.shinhan.knockknock.domain.entity.CardHistoryEntity;
 import com.shinhan.knockknock.domain.entity.MatchEntity;
 import com.shinhan.knockknock.domain.entity.NotificationEntity;
 import com.shinhan.knockknock.repository.CardHistoryRepository;
+import com.shinhan.knockknock.repository.CardRepository;
 import com.shinhan.knockknock.repository.MatchRepository;
 import com.shinhan.knockknock.repository.UserRepository;
 import com.shinhan.knockknock.service.notification.NotificationService;
@@ -15,6 +17,7 @@ import org.springframework.stereotype.Component;
 
 import java.sql.Timestamp;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -22,46 +25,9 @@ import java.util.List;
 public class SchedulerConfig {
     private final NotificationService notificationService;
     private final CardHistoryRepository cardHistoryRepository;
-    private final UserRepository userRepository;
     private final MatchRepository matchRepository;
+    private final CardRepository cardRepository;
 
-    //@Scheduled(fixedDelay = 60000)
-    public void notifyForOldCardHistory() {
-        // 현재 날짜에서 2일 전 날짜 계산
-        Timestamp twoDaysAgo = new Timestamp(System.currentTimeMillis() - (2 * 24 * 60 * 60 * 1000));
-        System.out.println("현재날짜 -2일 : " + twoDaysAgo);
-
-        // 조건에 맞는 cardHistory 조회
-        List<CardHistoryEntity> cardHistories = cardHistoryRepository.findByCardHistoryApproveBefore(twoDaysAgo);
-        System.out.println(cardHistories.size());
-
-        for (CardHistoryEntity cardHistory : cardHistories) {
-            Long cardId = cardHistory.getCardId();
-            Long userNo = cardHistory.getCard().getUserNo();
-
-            // 해당 userNo에게 알림을 보냅니다.
-            NotificationEntity notificationEntity = NotificationEntity.builder()
-                    .notificationCategory("카드 내역 알림")
-                    .notificationTitle("마지막 카드 사용 내역")
-                    .notificationContent("마지막 카드 사용 내역이 2일 이상 지난 항목이 있습니다.")
-                    .userNo(userNo)
-                    .build();
-            notificationService.notify(notificationEntity);
-
-            // 보호자가 있다면 보호자에게도 알림을 보냅니다.
-            MatchEntity matchEntity = matchRepository.findByUserProtege_UserNo(userNo).orElse(null);
-            if (matchEntity != null && matchEntity.getUserProtector() != null) {
-                Long protectorNo = matchEntity.getUserProtector().getUserNo();
-                NotificationEntity protectorNotification = NotificationEntity.builder()
-                        .notificationCategory("마지막 카드 내역 알림")
-                        .notificationTitle("보호자 알림")
-                        .notificationContent("보호자에게 연결된 사용자의 카드 사용 내역이 2일 이상 지난 항목이 있습니다.")
-                        .userNo(protectorNo)
-                        .build();
-                notificationService.notify(protectorNotification);
-            }
-        }
-    }
     /*
         @Scheduled 속성
         fixedRate: 작업 수행시간과 상관없이 일정 주기마다 메소드를 호출하는 것
@@ -69,14 +35,41 @@ public class SchedulerConfig {
         initialDelay: 스케줄러에서 메소드가 등록되자마자 수행하는 것이 아닌 초기 지연시간을 설정
         cron: Cron 표현식을 사용하여 작업을 예약
      */
-    //@Scheduled(fixedDelay = 10000 * 6 * 60)
-    public void SchedulerTest(){
-        NotificationEntity notificationEntity = NotificationEntity.builder()
-                .notificationCategory("스케줄러")
-                .notificationTitle("스케줄러 테스트")
-                .notificationContent("스케줄러 테스트")
-                .userNo(1L)
-                .build();
-        notificationService.notify(notificationEntity);
+
+    // 서버 시작 후 10초 뒤 한번 수행, 이후 1일 마다 수행
+    @Scheduled(initialDelay = 10000, fixedRate = 24 * 60 * 60 * 1000)
+    public void notifyForOldCardHistory() {
+        // 조건 2일 (현재 시간 - 2일)
+        Timestamp twoDaysAgo = new Timestamp(System.currentTimeMillis() - (2 * 24 * 60 * 60 * 1000));
+
+        // 모든 카드 ID 조회
+        List<Long> allCardIds = cardRepository.findAllCardIds();
+
+        // 2일 동안 사용 내역이 없는 카드 번호 조회
+        List<Long> cardIdsWithoutUse = cardHistoryRepository.findCardIdsWithoutRecentUse(twoDaysAgo);
+
+        // 모든 카드 ID 중 2일 이내에 사용되지 않은 카드 ID만 필터링
+        List<Long> cardIdsToNotify = allCardIds.stream()
+                .filter(cardIdsWithoutUse::contains)
+                .toList();
+
+        // 필터링된 카드들에 대해 매칭된 보호자의 userNo를 찾아 알림 전송
+        for (Long cardId : cardIdsToNotify) {
+            CardEntity card = cardRepository.findById(cardId).orElse(null);
+            if (card != null) {
+                Long userNo = card.getUserNo();
+                MatchEntity matchEntity = matchRepository.findByUserProtege_UserNo(userNo).orElse(null);
+                if (matchEntity != null && matchEntity.getUserProtector() != null) {
+                    Long protectorNo = matchEntity.getUserProtector().getUserNo();
+                    NotificationEntity protectorNotification = NotificationEntity.builder()
+                            .notificationCategory("이상 징후")
+                            .notificationTitle("매칭된 사용자 카드 미사용 2일 이상 경과")
+                            .notificationContent("매칭된 사용자의 카드가 2일 이상 사용되지 않았습니다. 상황을 확인해 주세요.")
+                            .userNo(protectorNo)
+                            .build();
+                    notificationService.notify(protectorNotification);
+                }
+            }
+        }
     }
 }

--- a/src/main/java/com/shinhan/knockknock/repository/CardHistoryRepository.java
+++ b/src/main/java/com/shinhan/knockknock/repository/CardHistoryRepository.java
@@ -34,6 +34,13 @@ public interface CardHistoryRepository extends JpaRepository<CardHistoryEntity, 
     List<CardHistoryEntity> findByCard_CardId(Long cardId, PageRequest pageRequest);
     List<CardHistoryEntity> findByCard_CardId(Long cardId, Sort sort);
     List<CardHistoryEntity> findByCard_CardIdAndCardHistoryApproveBetween(Long cardId, Timestamp startDate, Timestamp endDate, Sort sort);
-    List<CardHistoryEntity> findByCardHistoryApproveBefore(Timestamp startDate);
+
+    // 2일 이내에 사용 내역이 없는 카드 조회
+    @Query("SELECT c.cardId FROM CardEntity c " +
+            "WHERE c.cardId NOT IN (" +
+            "  SELECT ch.card.cardId FROM CardHistoryEntity ch " +
+            "  WHERE ch.cardHistoryApprove >= :twoDaysAgo" +
+            ")")
+    List<Long> findCardIdsWithoutRecentUse(@Param("twoDaysAgo") Timestamp twoDaysAgo);
 
 }

--- a/src/main/java/com/shinhan/knockknock/repository/CardRepository.java
+++ b/src/main/java/com/shinhan/knockknock/repository/CardRepository.java
@@ -16,10 +16,12 @@ public interface CardRepository extends JpaRepository<CardEntity, Long> {
     @Query("SELECT c FROM CardEntity c WHERE c.userNo = :userNo")
     List<CardEntity> findCardByUserNo(@Param("userNo") Long userNo);
 
+    @Query("SELECT c.cardId FROM CardEntity c")
+    List<Long> findAllCardIds();
+
     // 보호자 번호와 가족 카드 여부로 카드 조회
     @Query("SELECT c FROM CardEntity c WHERE c.userNo = :userNo AND c.cardIsfamily = true")
     List<CardEntity> findFamilyCardsByUserNo(@Param("userNo") Long userNo);
-
 
     // 이름과 전화번호로 CardEntity 조회
     @Query("SELECT c FROM CardEntity c WHERE c.cardUserKname = :cardUserKname AND c.cardUserPhone = :cardUserPhone")


### PR DESCRIPTION
## 🌟(#174) 이상 징후 알림 구현


## ✍️내용
- 일정 기간(2일로 설정) 소비내역이 없는 카드를 조회하여 매칭된 보호자에게 알림을 보냄
- 서버 시작시 한번 수행하고 이후 1일마다 알림

## 📸스크린샷


## 🎈참고사항

## ✅PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [x] main 브랜치에 PR 요청 인지 develop 브랜치에 PR 요청 인지 확인했습니다.